### PR TITLE
add uplot (youplot) library for plotting variables

### DIFF
--- a/mdb/mdb_attach.py
+++ b/mdb/mdb_attach.py
@@ -43,10 +43,21 @@ from .mdb_shell import mdbShell
     show_default=True,
     help="By default mdb will search for the first breakpoint (main or MAIN__). You can chose to override this by manually specifying a specific breakpoint.",
 )
-def attach(ranks, select, host, port, program, breakpt):
+@click.option(
+    "--plot-lib",
+    default="uplot",
+    show_default=True,
+    help="Plotting library to use. Recommended default is [uplot] but if this is not available [matplotlib] will be used. [matplotlib] is best if there are many ranks to debug e.g., -s 0-100.",
+)
+def attach(ranks, select, host, port, program, breakpt, plot_lib):
     # debug all ranks if "select" is not set
     if select == "":
         select = ",".join([str(rank) for rank in list(range(ranks))])
+
+    supported_plot_libs = ["uplot", "matplotlib"]
+    if plot_lib not in supported_plot_libs:
+        msg = f"warning: unrecognized plot library [{plot_lib}]. Supported libraries are [{supported_plot_libs}]."
+        raise ValueError(msg)
 
     prog_opts = dict(
         ranks=ranks,
@@ -55,6 +66,7 @@ def attach(ranks, select, host, port, program, breakpt):
         port=port,
         program=program,
         breakpt=breakpt,
+        plot_lib=plot_lib,
     )
 
     client = Client(prog_opts)


### PR DESCRIPTION
`uplot` is a command line tool that draw plots on the terminal.

This helps to keep the user in terminal and not breakout to a GUI from `matplotlib`. However, `matplotlib` is still available. And it could be beneficial to use `matplotlib` if the number of debug ranks (`-s`) is greater than e.g. 10.