### PR TITLE
fix install of mdb in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -29,4 +29,8 @@ formats:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
-   - requirements: docs/requirements.txt
+   - method: pip
+     path: .
+     extra_requirements:
+       - docs
+       - develop


### PR DESCRIPTION
readthedocs was not building mdb and as a result the API and click documentation could not be auto-generated.

This fixes the issue.