### PR TITLE
Added stdin filter for `interact`

### DIFF
--- a/mdb/mdb_shell.py
+++ b/mdb/mdb_shell.py
@@ -56,15 +56,21 @@ def buffered_input_filter(
         the backspace characters needed to remove the current string.
     """
 
-    def input_filter(s: bytes, data: list[str] = [""]) -> bytes:
+    # closure memory
+    # we use a list with a single item to avoid unbounds
+    data = [""]
+
+    def input_filter(s: bytes) -> bytes:
         c = s.decode()
         if c == "\n" or c == "\r":
             response = handle_input(data[0])
-            # clear the buffer
+            # clear the buffer for next command
             data[0] = ""
             if response:
                 return response.encode()
         elif c == chr(4):  # catch ctrl-d
+            # clear the buffer to avoid persistence between interacts
+            data[0] = ""
             return INTERACT_ESCAPE_CHARACTER.encode()
         else:
             data[0] += c

--- a/mdb/mdb_shell.py
+++ b/mdb/mdb_shell.py
@@ -42,10 +42,11 @@ def buffered_input_filter(
     """Wrap functions to generate arguments for `pexpect.interact` filters.
 
     Wraps a callback function with a buffer so that instead of receiving each
-    character as it is typed, the filter function is given the currently
-    enterec command. The wrapper also augments/overrides the interaction with
-    common substitutions for control characters, e.g. `Ctrl-d` will send
-    `INTERACT_ESCAPE_CHARACTER`.
+    character as it is typed, the filter function is given the current command
+    string. The wrapper also augments/overrides the interaction with common
+    substitutions for control characters:
+    - `Ctrl-d` will send `INTERACT_ESCAPE_CHARACTER` to end the interaction
+      instead of `quit` to the gdb shell.
 
     The `handle_input` argument is only called after each newline or carriage
     return, and should return the modified input to be sent to the shell.

--- a/mdb/mdb_shell.py
+++ b/mdb/mdb_shell.py
@@ -128,7 +128,8 @@ class mdbShell(cmd.Cmd):
             escape_character=INTERACT_ESCAPE_CHARACTER,
             input_filter=buffered_input_filter(input_filter),
         )
-        sys.stdout.write("\r")
+        # newline incase there was a command in progress when interaction quit
+        sys.stdout.write("\n")
         return
 
     def do_info(self, line: str) -> None:

--- a/mdb/mdb_shell.py
+++ b/mdb/mdb_shell.py
@@ -51,11 +51,13 @@ def buffered_input_filter(
       instead of `quit` to the gdb shell.
 
     The `handle_input` argument is only called after each newline or carriage
-    return, and should return the modified input to be sent to the shell.
+    return, and should return characters to be sent to the GDB shell else an
+    empty string.
 
-    Warning:
-        If `handle_input` is to replace the current input, it must also include
-        the backspace characters needed to remove the current string.
+    Note that if `handle_input` is to modify the string in any way other than
+    by sending new characters to the shell, it must also include the backspace
+    characters needed to remove (parts of) the current string and include the
+    newline character to execute the command in GDB.
     """
 
     # closure memory


### PR DESCRIPTION
This can be used as a building block to add all sorts of custom commands to the gdb interactions. 

This PR implements the minimum needed to avoid users accidentally killing the GDB instance by quitting or EOF'ing whilst in an interaction, and instead simply ends the interaction returning the user to the MDB shell.

Some potential future use cases that could be added with this:
- interacting with a given process at a breakpoint, and within that interaction stepping all processes simultaneously (allows the user to e.g. keep TUI mode going whilst they are stepping through code)
- stepping a different process B whilst interacting with A to see how e.g. the MPI comms are sent/received by A
- quickly getting data from B whilst interacting with A without having to quit the interaction
