### PR TITLE
Improve handling of closed debug processes

### DIFF
--- a/mdb/mdb_client.py
+++ b/mdb/mdb_client.py
@@ -32,17 +32,19 @@ class Client:
     def close_procs(self) -> None:
         """Close all open processes."""
 
-        with Progress(
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            MofNCompleteColumn(),
-        ) as progress:
-            connect_progress = progress.add_task(
-                "Closing processes...", total=self.ranks
-            )
-            for proc in self.dbg_procs:
-                proc.close()
-                progress.advance(connect_progress)
+        if self.dbg_procs:
+            with Progress(
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(),
+                MofNCompleteColumn(),
+            ) as progress:
+                connect_progress = progress.add_task(
+                    "Closing processes...", total=self.ranks
+                )
+                for proc in self.dbg_procs:
+                    proc.close()
+                    progress.advance(connect_progress)
+            self.dbg_procs = []
         return
 
     def clear_stdout(self) -> None:


### PR DESCRIPTION
Currently the debug processes can be closed but the user may not be notified. This can lead to them submitting commands that don't do anything with no feedback.

These changes to `mdb/mdb_client.py` and `mdb/mdb_shell.py` provide a warning when all debug processes `client.dbg_procs` are closed.

This may also pave the way for handling debug session restarts (pending a re-write of the `mdb launcher`).