### PR TITLE
add broadcast mode

### DIFF
--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -197,6 +197,33 @@ In theory you now have enough information to start debugging your own programs. 
 this simple example if you want to get to grips with ``mdb``. There are a couple more useful things
 I want to show you though before you leave.
 
+Broadcast mode
+--------------
+
+Whilst the ``command`` command is pretty useful. For long debugging sessions it can be annoying
+constantly prefixing ``command`` to every ``gdb`` command you want to run. This is where broadcast
+mode comes in handy. In broadcast mode all commands will be automatically prefixed with ``command``
+so that they run on the selected ranks. By default all ranks are selected unless you have manually
+specified a different selection with the ``select`` command.
+
+To enter broadcast mode type the following,
+
+.. code-block:: console
+
+   (mdb 0-7) broadcast start
+   (bct 0-7)
+
+The command prompt will turn to ``(bct 0-7)`` and will also change color to yellow (depending on
+your terminal color scheme). To leave broadcast mode either press ``CTRL+D`` or type
+``quit``/``broadcast stop``, e.g.,
+
+.. code-block:: console
+
+   (bct 0-7) broadcast stop
+   (mdb 0-7)
+
+The prompt should return to ``(mdb 0-7)`` and be back to the standard font color.
+
 Interactive mode
 ----------------
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,45 +19,49 @@ command continue
 execute deliberately-missing-file.mdb
 status
 select 0-1
+!echo hello
+broadcast start
+p 5*5
+broadcast stop
 command continue
 command quit
-!echo hello
 quit
 """
 
 ans_text = """Connecting processes... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2
+hello
 mdb - mpi debugger - built on gdb. Type ? for more info. To exit interactive mode type "q", "quit", "Ctrl+D" or "Ctrl+]".
-0:process 100561
-0:cmdline = './examples/simple-mpi.exe'
-0:cwd = '/home/melt/sync/cambridge/projects/side/mdb'
-0:exe = '/home/melt/sync/cambridge/projects/side/mdb/examples/simple-mpi.exe'
-
-1:process 100566
+1:process 127650
 1:cmdline = './examples/simple-mpi.exe'
 1:cwd = '/home/melt/sync/cambridge/projects/side/mdb'
 1:exe = '/home/melt/sync/cambridge/projects/side/mdb/examples/simple-mpi.exe'
+
+0:process 127646
+0:cmdline = './examples/simple-mpi.exe'
+0:cwd = '/home/melt/sync/cambridge/projects/side/mdb'
+0:exe = '/home/melt/sync/cambridge/projects/side/mdb/examples/simple-mpi.exe'
 
 1:Breakpoint 2 at 0x5555555552da: file simple-mpi.f90, line 15.
 
 0:Breakpoint 2 at 0x5555555552da: file simple-mpi.f90, line 15.
 
-1:Breakpoint 3 at 0x5555555552f6: file simple-mpi.f90, line 17.
-
 0:Breakpoint 3 at 0x5555555552f6: file simple-mpi.f90, line 17.
 
-1:Continuing.
-1:[New Thread 100566.100596]
-1:[New Thread 100566.100598]
-1:
-1:Thread 1 "simple-mpi.exe" hit Breakpoint 2, simple () at simple-mpi.f90:15
-1:15  var = 10.*process_rank
+1:Breakpoint 3 at 0x5555555552f6: file simple-mpi.f90, line 17.
 
 0:Continuing.
-0:[New Thread 100561.100597]
-0:[New Thread 100561.100599]
+0:[New Thread 127646.127717]
+0:[New Thread 127646.127719]
 0:
 0:Thread 1 "simple-mpi.exe" hit Breakpoint 2, simple () at simple-mpi.f90:15
 0:15  var = 10.*process_rank
+
+1:Continuing.
+1:[New Thread 127650.127718]
+1:[New Thread 127650.127720]
+1:
+1:Thread 1 "simple-mpi.exe" hit Breakpoint 2, simple () at simple-mpi.f90:15
+1:15  var = 10.*process_rank
 
 0:Continuing.
 0:
@@ -77,11 +81,9 @@ unrecognized command [made-up-command]. Type help to find out list of possible c
 
 File [deliberately-missing-file.mdb] not found. Please check the file exists and try again.
 0 1
-1:Continuing.
-1:
-1:Thread 1 "simple-mpi.exe" received signal SIGINT, Interrupt.
-1:simple () at simple-mpi.f90:15
-1:15  var = 10.*process_rank
+0:$1 = 25
+
+1:$1 = 25
 
 0:Continuing.
 0:
@@ -89,8 +91,13 @@ File [deliberately-missing-file.mdb] not found. Please check the file exists and
 0:simple () at simple-mpi.f90:17
 0:17  if (process_rank == 0) then
 
+1:Continuing.
+1:
+1:Thread 1 "simple-mpi.exe" received signal SIGINT, Interrupt.
+1:simple () at simple-mpi.f90:15
+1:15  var = 10.*process_rank
+
 Closing processes... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2
-warning: no debug processes running. Please relaunch the debugger
 
 exiting mdb...
 """


### PR DESCRIPTION
* add broadcast mode to mdb shell
* add broadcast mode to integration test
* add example to quickstart docs

Broadcast mode (bcm) sends commands to the selected ranks (see help select for more info). Broadcast mode is enabled/(disabled) by typing broadcast start/(stop). To exit broadcast mode, enter command [broadcast stop] or [quit] or press CTRL+D.

Example:
The following command will start broadcast mode.

    (mdb) broadcast start