### PR TITLE
sort output from do_command

### DIFF
--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -76,22 +76,22 @@ default, but for this tutorial I am running (and compiling) with open MPI (and `
 .. code-block:: console
 
    $ mdb launch -n 8 ./simple-mpi.exe
-   Process ./simple-mpi.exe created; pid = 62872
-   Listening on port 2006
-   Process ./simple-mpi.exe created; pid = 62876
-   Listening on port 2002
-   Process ./simple-mpi.exe created; pid = 62881
-   Listening on port 2003
-   Process ./simple-mpi.exe created; pid = 62887
-   Listening on port 2004
-   Process ./simple-mpi.exe created; pid = 62891
-   Listening on port 2005
-   Process ./simple-mpi.exe created; pid = 62896
+   Process ./simple-mpi.exe created; pid = 169875
    Listening on port 2000
-   Process ./simple-mpi.exe created; pid = 62901
-   Listening on port 2007
-   Process ./simple-mpi.exe created; pid = 62906
+   Process ./simple-mpi.exe created; pid = 169879
    Listening on port 2001
+   Process ./simple-mpi.exe created; pid = 169883
+   Listening on port 2002
+   Process ./simple-mpi.exe created; pid = 169887
+   Listening on port 2003
+   Process ./simple-mpi.exe created; pid = 169892
+   Listening on port 2004
+   Process ./simple-mpi.exe created; pid = 169895
+   Listening on port 2005
+   Process ./simple-mpi.exe created; pid = 169898
+   Listening on port 2006
+   Process ./simple-mpi.exe created; pid = 169901
+   Listening on port 2007
 
 
 **Note**: You can start ``mdb launch`` in ``--auto-restart`` mode so that it will automatically
@@ -156,28 +156,32 @@ that any commands issued via ``command`` will be sent to processors ``0-7``. For
 .. code-block:: console
 
    (mdb 0-7) command info proc
-   1:      process 62906
+   0:      process 169875
+   0:      cmdline = './simple-mpi.exe'
+   0:      cwd = '/home/melt/sync/cambridge/projects/side/mdb/examples'
+   0:      exe = '/home/melt/sync/cambridge/projects/side/mdb/examples/simple-mpi.exe'
+   ------------------------------------------------------------------------
+   1:      process 169879
    1:      cmdline = './simple-mpi.exe'
-   1:      cwd = '/home/melt/mdb/examples'
-   1:      exe = '/home/melt/mdb/examples/simple-mpi.exe'
-
-   7:      process 62901
-   7:      cmdline = './simple-mpi.exe'
-   7:      cwd = '/home/melt/mdb/examples'
-   7:      exe = '/home/melt/mdb/examples/simple-mpi.exe'
 
    ...
 
-   0:      process 62896
-   0:      cmdline = './simple-mpi.exe'
-   0:      cwd = '/home/melt/mdb/examples'
-   0:      exe = '/home/melt/mdb/examples/simple-mpi.exe'
+   6:      cwd = '/home/melt/sync/cambridge/projects/side/mdb/examples'
+   6:      exe = '/home/melt/sync/cambridge/projects/side/mdb/examples/simple-mpi.exe'
+   ------------------------------------------------------------------------
+   7:      process 169901
+   7:      cmdline = './simple-mpi.exe'
+   7:      cwd = '/home/melt/sync/cambridge/projects/side/mdb/examples'
+   7:      exe = '/home/melt/sync/cambridge/projects/side/mdb/examples/simple-mpi.exe'
+   ------------------------------------------------------------------------
 
 From brevity I have used ``...`` to shorten the output. ``command`` is used to send commands
-directly to the ``gdb`` instance of each processor. In this case I sent ``info proc`` which prints
-information on each process. Notice that the process id's match those from the ``launch`` command.
-Whilst there is no guarantee for the order of output, each process will have it's process rank id
-prepended to the output in the format ``[rank id]:`` . If you want to issue a ``gdb`` command to a
+directly to the ``gdb`` instance of each processor (see :ref:`broadcast_mode` which covers the
+``broadcast`` command -- this is useful for longer debug sessions). In this case I sent ``info
+proc`` which prints information on each process. Notice that the process id's match those from the
+``launch`` command. The output is sorted in numerical order with each process having it's own rank
+id prepended to the output in the format ``[rank id]:``. Each rank's output is separated by a
+dividing line of hyphen characters i.e., ``---``. If you want to issue a ``gdb`` command to a
 specific rank (or set of ranks) only then you can provide an optional set of ranks, either
 comma-separated, hyphen-separated or a mix of both. For example, to send command ``backtrace -1`` to
 ranks ``0,2-4`` use the following.
@@ -196,6 +200,8 @@ ranks ``0,2-4`` use the following.
 In theory you now have enough information to start debugging your own programs. Have a play with
 this simple example if you want to get to grips with ``mdb``. There are a couple more useful things
 I want to show you though before you leave.
+
+.. _broadcast_mode:
 
 Broadcast mode
 --------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,6 +7,7 @@ from typing import Union
 from mdb.utils import strip_bracketted_paste, strip_control_characters
 
 script_text = """# this is a simple test script
+!echo hello
 command info proc
 command b simple-mpi.f90:15
 command b simple-mpi.f90:17
@@ -19,7 +20,6 @@ command continue
 execute deliberately-missing-file.mdb
 status
 select 0-1
-!echo hello
 broadcast start
 p 5*5
 broadcast stop
@@ -31,72 +31,72 @@ quit
 ans_text = """Connecting processes... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2
 hello
 mdb - mpi debugger - built on gdb. Type ? for more info. To exit interactive mode type "q", "quit", "Ctrl+D" or "Ctrl+]".
-1:process 127650
-1:cmdline = './examples/simple-mpi.exe'
-1:cwd = '/home/melt/sync/cambridge/projects/side/mdb'
-1:exe = '/home/melt/sync/cambridge/projects/side/mdb/examples/simple-mpi.exe'
-
-0:process 127646
+0:process 165478
 0:cmdline = './examples/simple-mpi.exe'
 0:cwd = '/home/melt/sync/cambridge/projects/side/mdb'
 0:exe = '/home/melt/sync/cambridge/projects/side/mdb/examples/simple-mpi.exe'
-
-1:Breakpoint 2 at 0x5555555552da: file simple-mpi.f90, line 15.
-
+------------------------------------------------------------------------
+1:process 165481
+1:cmdline = './examples/simple-mpi.exe'
+1:cwd = '/home/melt/sync/cambridge/projects/side/mdb'
+1:exe = '/home/melt/sync/cambridge/projects/side/mdb/examples/simple-mpi.exe'
+------------------------------------------------------------------------
 0:Breakpoint 2 at 0x5555555552da: file simple-mpi.f90, line 15.
-
+------------------------------------------------------------------------
+1:Breakpoint 2 at 0x5555555552da: file simple-mpi.f90, line 15.
+------------------------------------------------------------------------
 0:Breakpoint 3 at 0x5555555552f6: file simple-mpi.f90, line 17.
-
+------------------------------------------------------------------------
 1:Breakpoint 3 at 0x5555555552f6: file simple-mpi.f90, line 17.
-
+------------------------------------------------------------------------
 0:Continuing.
-0:[New Thread 127646.127717]
-0:[New Thread 127646.127719]
+0:[New Thread 165478.165519]
+0:[New Thread 165478.165521]
 0:
 0:Thread 1 "simple-mpi.exe" hit Breakpoint 2, simple () at simple-mpi.f90:15
 0:15  var = 10.*process_rank
-
+------------------------------------------------------------------------
 1:Continuing.
-1:[New Thread 127650.127718]
-1:[New Thread 127650.127720]
+1:[New Thread 165481.165518]
+1:[New Thread 165481.165520]
 1:
 1:Thread 1 "simple-mpi.exe" hit Breakpoint 2, simple () at simple-mpi.f90:15
 1:15  var = 10.*process_rank
-
+------------------------------------------------------------------------
 0:Continuing.
 0:
 0:Thread 1 "simple-mpi.exe" hit Breakpoint 3, simple () at simple-mpi.f90:17
 0:17  if (process_rank == 0) then
-
+------------------------------------------------------------------------
 0:#0  simple () at simple-mpi.f90:17
-
+------------------------------------------------------------------------
 1:#0  simple () at simple-mpi.f90:15
-
+------------------------------------------------------------------------
 unrecognized command [made-up-command]. Type help to find out list of possible commands.
 1:Continuing.
 1:
 1:Thread 1 "simple-mpi.exe" received signal SIGINT, Interrupt.
 1:simple () at simple-mpi.f90:15
 1:15  var = 10.*process_rank
-
+------------------------------------------------------------------------
 File [deliberately-missing-file.mdb] not found. Please check the file exists and try again.
 0 1
 0:$1 = 25
-
+------------------------------------------------------------------------
 1:$1 = 25
-
+------------------------------------------------------------------------
 0:Continuing.
 0:
 0:Thread 1 "simple-mpi.exe" received signal SIGINT, Interrupt.
 0:simple () at simple-mpi.f90:17
 0:17  if (process_rank == 0) then
-
+------------------------------------------------------------------------
 1:Continuing.
 1:
 1:Thread 1 "simple-mpi.exe" received signal SIGINT, Interrupt.
 1:simple () at simple-mpi.f90:15
 1:15  var = 10.*process_rank
-
+------------------------------------------------------------------------
 Closing processes... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2
 
 exiting mdb...
@@ -118,10 +118,8 @@ def strip_runtime_specific_output(text: str) -> str:
 
 
 def standardize_output(text: str) -> str:
-    # remove process and thread ids
+    # remove process and thread ids and other system specific output
     text = strip_runtime_specific_output(text)
-    # sort output lines in alphabetical order
-    text = "\n".join(sorted(text.splitlines()))
 
     def filter_mask(line: str) -> Union[str, None]:
         if re.search(r"\d+:Reading.*from remote target...", line):


### PR DESCRIPTION
output from `do_command` is now sorted in rank order.

I have updated the integration test and expanded the quickstart documentation.