### PR TITLE
Bugfix ctrl c

### DIFF
--- a/mdb/debug_client.py
+++ b/mdb/debug_client.py
@@ -71,7 +71,9 @@ class DebugClient(AsyncClient):
             self.dbg_proc.sendintr()
             await self.dbg_proc.expect(self.backend.prompt_string, async_=True)
             # report on how that all went
-            output = f"\r\nInterrupted: {success}\r\n"
+            output = self.dbg_proc.before.decode()
+            output = strip_bracketted_paste(output)
+            output += f"\r\nInterrupted: {success}\r\n"
 
         else:
             select = message.data["select"]

--- a/mdb/debug_client.py
+++ b/mdb/debug_client.py
@@ -56,7 +56,6 @@ class DebugClient(AsyncClient):
         self, message: Message, prev: Optional[asyncio.Task[Any]]
     ) -> None:
         command = message.data["command"]
-        select = message.data["select"]
         output = ""
         if command == "interrupt":
             logger.warning("Interrupt received")
@@ -75,6 +74,7 @@ class DebugClient(AsyncClient):
             output = f"\r\nInterrupted: {success}\r\n"
 
         else:
+            select = message.data["select"]
             logger.debug("Running command: '%s'", command)
             logger.debug("self.myrank = %d", self.myrank)
             if self.myrank in select:


### PR DESCRIPTION
Currently `ctrl+c` doesn't function properly. It should send interrupt to the running debug procs. Due to a bug that this PR fixes it was not executing the command properly.

- [x] add output text of interrupted process
- [x] fix ctrl-c signal