### PR TITLE
Bugfix race condition

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 3
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -25,8 +25,8 @@ jobs:
     - name: Install mdb and additional python packages
       run: |
         pip install -e .[develop,termgraph]
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v3
     - name: Run tests
       run: |
         pytest --cov-report term-missing --cov-report json:cov.json --cov=mdb -vv tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,9 @@ jobs:
         pip install -e .[develop,termgraph]
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
+      run: |
+        git clone https://github.com/TomMelt/dotfiles.git ~/.dotfiles
+        ln -sf ~/.dotfiles/.tmux.conf .
     - name: Run tests
       run: |
         pytest --cov-report term-missing --cov-report json:cov.json --cov=mdb -vv tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,9 +28,10 @@ jobs:
     - name: debug config
       run: |
         git clone https://github.com/TomMelt/dotfiles.git ~/.dotfiles
-        ln -sf ~/.dotfiles/.tmux.conf .
-        ln -sf ~/.dotfiles/.gitconfig .
+        ln -sf ~/.dotfiles/.tmux.conf $HOME/
+        ln -sf ~/.dotfiles/.gitconfig $HOME/
         cat ~/.dotfiles/.bash_aliases >> $HOME/.bashrc
+        source $HOME/.bashrc
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
     - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,11 +25,14 @@ jobs:
     - name: Install mdb and additional python packages
       run: |
         pip install -e .[develop,termgraph]
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
+    - name: debug config
       run: |
         git clone https://github.com/TomMelt/dotfiles.git ~/.dotfiles
         ln -sf ~/.dotfiles/.tmux.conf .
+        ln -sf ~/.dotfiles/.gitconfig .
+        cat ~/.dotfiles/.bash_aliases >> $HOME/.bashrc
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Run tests
       run: |
         pytest --cov-report term-missing --cov-report json:cov.json --cov=mdb -vv tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt update
-        sudo apt install -y gdb libopenmpi-dev libssl-dev clang
+        sudo apt install -y gdb libopenmpi-dev libssl-dev lldb
     - name: Build example mpi program
       run: |
         make -C examples/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Install mdb and additional python packages
       run: |
         pip install -e .[develop,termgraph]
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Run tests
       run: |
         pytest --cov-report term-missing --cov-report json:cov.json --cov=mdb -vv tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,10 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3
       with:
         python-version: '3.11'
     - name: Install system dependencies
@@ -27,6 +25,8 @@ jobs:
     - name: Install mdb and additional python packages
       run: |
         pip install -e .[develop,termgraph]
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Run tests
       run: |
         pytest --cov-report term-missing --cov-report json:cov.json --cov=mdb -vv tests/

--- a/src/mdb/async_client.py
+++ b/src/mdb/async_client.py
@@ -42,8 +42,8 @@ class AsyncClient(ABC):
                 self.exchange_hostname, self.exchange_port, ssl=self.context
             )
             self.conn = AsyncConnection(reader, writer)
-        except Exception as e:
-            logger.exception("init connection error")
+        except ConnectionRefusedError as e:
+            logger.debug("init connection error")
             raise e
 
     async def connect_to_exchange(self, msg: "Message") -> "Message":

--- a/src/mdb/async_connection.py
+++ b/src/mdb/async_connection.py
@@ -22,9 +22,10 @@ class AsyncConnection:
     async def recv_message(self) -> "Message":
         try:
             raw_msg = await self.reader.readuntil(separator=END_BYTES)
-        except Exception as e:
-            logger.exception("async read error")
-            raise e
+        except asyncio.IncompleteReadError:
+            # if connection drops we return None
+            # this can happen when the user force closes the attach client
+            return
         msg = Message.from_json(raw_msg)
         logger.debug("msg received [%s]", msg.msg_type)
         return msg

--- a/src/mdb/debug_client.py
+++ b/src/mdb/debug_client.py
@@ -35,10 +35,6 @@ class DebugClient(AsyncClient):
         else:
             args = ""
 
-        print("backend.debug_command = ", backend.debug_command)
-        print("backend.argument_separator = ", backend.argument_separator)
-        print("self.target = ", self.target)
-        print("args = ", args)
         debug_command = " ".join(
             [backend.debug_command, backend.argument_separator, self.target, args]
         )

--- a/src/mdb/exchange_server.py
+++ b/src/mdb/exchange_server.py
@@ -122,26 +122,6 @@ class AsyncExchangeServer:
         )
         return task
 
-    def listen(self) -> None:
-        # either pass in an event loop, or make one
-        loop = asyncio.get_event_loop()
-
-        # TODO: to get better control of the server, we can wrap our own
-        # transport layer and then add a system of hooks for logging or other
-        # events. For example, if a debug client loses connection, the exchange
-        # server should let the user know somehow. By using the library
-        # `start_server`, we lose some of that control, but lets us move
-        # faster.
-        task = asyncio.start_server(
-            self.handle_connection,
-            self.hostname,
-            self.port,
-            ssl=self.context,
-        )
-
-        loop.run_until_complete(task)
-        loop.run_forever()
-
     async def shutdown(self, signame: str) -> None:
         """Cleanup tasks tied to the service's shutdown."""
         loop = asyncio.get_event_loop()

--- a/src/mdb/mdb_launch.py
+++ b/src/mdb/mdb_launch.py
@@ -168,7 +168,9 @@ def launch(
 
     cmd = wrapper_launcher.launch_command()
     logger.debug(f"launch command: {cmd}")
-    launch_task = loop.create_task(asyncio.create_subprocess_exec(*shlex.split(cmd)))
+    launch_task = loop.create_task(
+        asyncio.create_subprocess_exec(*shlex.split(cmd)), name="launch_task"
+    )
 
     exchange_opts = {
         "hostname": hostname,
@@ -178,7 +180,7 @@ def launch(
         "launch_task": launch_task,
     }
     server = AsyncExchangeServer(opts=exchange_opts)
-    loop.create_task(server.start_server())
+    loop.create_task(server.start_server(), name="starting server")
 
     for s in [signal.SIGINT, signal.SIGTERM]:
 

--- a/src/mdb/messages.py
+++ b/src/mdb/messages.py
@@ -5,7 +5,7 @@ import json
 from dataclasses import dataclass
 from typing import Any
 
-MDB_CLIENT = "mdb client"
+ATTACH_CLIENT = "attach client"
 DEBUG_CLIENT = "debug client"
 EXCHANGE = "exchange server"
 
@@ -43,7 +43,7 @@ class Message:
     def mdb_conn_request() -> "Message":
         return Message(
             "mdb_conn_request",
-            {"from": MDB_CLIENT, "to": EXCHANGE},
+            {"from": ATTACH_CLIENT, "to": EXCHANGE},
         )
 
     @staticmethod
@@ -52,7 +52,7 @@ class Message:
             "mdb_conn_response",
             {
                 "from": EXCHANGE,
-                "to": MDB_CLIENT,
+                "to": ATTACH_CLIENT,
                 "no_of_ranks": no_of_ranks,
                 "backend_name": backend_name,
             },
@@ -63,7 +63,7 @@ class Message:
         return Message(
             "mdb_command_request",
             {
-                "from": MDB_CLIENT,
+                "from": ATTACH_CLIENT,
                 "to": EXCHANGE,
                 "command": command,
                 "select": select,
@@ -75,7 +75,7 @@ class Message:
         return Message(
             "mdb_interrupt_request",
             {
-                "from": MDB_CLIENT,
+                "from": ATTACH_CLIENT,
                 "to": EXCHANGE,
                 "command": "interrupt",
             },
@@ -101,7 +101,7 @@ class Message:
             "exchange_command_response",
             {
                 "from": EXCHANGE,
-                "to": MDB_CLIENT,
+                "to": ATTACH_CLIENT,
                 "results": results,
             },
         )

--- a/tests/output/mdb-attach-log
+++ b/tests/output/mdb-attach-log
@@ -1,0 +1,32 @@
+DEBUG:asyncio:Using selector: EpollSelector
+DEBUG:mdb.async_client:init connection error
+INFO:root:Attempt 0 to connect to exchange server.
+INFO:root:sleeping for 1s
+DEBUG:mdb.async_client:init connection error
+INFO:root:Attempt 1 to connect to exchange server.
+INFO:root:sleeping for 1s
+DEBUG:mdb.async_client:init connection error
+INFO:root:Attempt 2 to connect to exchange server.
+INFO:root:sleeping for 1s
+DEBUG:mdb.async_client:init connection error
+INFO:root:Attempt 3 to connect to exchange server.
+INFO:root:sleeping for 1s
+DEBUG:mdb.async_client:init connection error
+INFO:root:Attempt 4 to connect to exchange server.
+INFO:root:sleeping for 1s
+DEBUG:mdb.async_client:init connection error
+INFO:root:Attempt 5 to connect to exchange server.
+INFO:root:sleeping for 1s
+DEBUG:mdb.async_client:init connection error
+INFO:root:Attempt 6 to connect to exchange server.
+INFO:root:sleeping for 1s
+DEBUG:mdb.async_client:init connection error
+INFO:root:Attempt 7 to connect to exchange server.
+INFO:root:sleeping for 1s
+DEBUG:mdb.async_client:init connection error
+INFO:root:Attempt 8 to connect to exchange server.
+INFO:root:sleeping for 1s
+DEBUG:mdb.async_client:init connection error
+INFO:root:Attempt 9 to connect to exchange server.
+INFO:root:sleeping for 1s
+ERROR:mdb.mdb_attach:couldn't connect to exchange server at localhost:2000.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -86,7 +86,7 @@ def run_test_for_backend(launch_command: str, name: str, backend_script: str):
 
         # run mdb attach and collect the stdout
         result = run(
-            shlex.split("mdb attach -x integration.mdb"),
+            shlex.split("mdb attach -h localhost -x integration.mdb"),
             capture_output=True,
         )
 
@@ -140,7 +140,7 @@ quit
 
 
 def test_mdb_gdb() -> None:
-    launch_command = "mdb launch -b gdb -t examples/simple-mpi.exe -n 2"
+    launch_command = "mdb launch -b gdb -t examples/simple-mpi.exe -n 2 -h localhost"
     run_test_for_backend(launch_command, "gdb", script_gdb)
 
 
@@ -167,7 +167,9 @@ quit
 
 
 def test_mdb_lldb() -> None:
-    launch_command = "mdb launch -b lldb -t examples/simple-mpi-cpp.exe -n 2"
+    launch_command = (
+        "mdb launch -b lldb -t examples/simple-mpi-cpp.exe -n 2 -h localhost"
+    )
     run_test_for_backend(launch_command, "lldb", script_lldb)
 
 
@@ -183,7 +185,7 @@ def test_mdb_timeout() -> None:
     # remove existing log file
     os.remove("mdb-attach.log")
     # run mdb attach without start mdb launch
-    run(shlex.split("mdb attach --log-level DEBUG"))
+    run(shlex.split("mdb attach --log-level DEBUG -h localhost"))
 
     with open("mdb-attach.log") as logfile:
         result_txt = "".join(logfile.readlines())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -45,7 +45,7 @@ def strip_runtime_specific_output(text: str) -> str:
     # remove absolute exe
     text = re.sub(r"exe = '[\/\w]+/simple-mpi.exe'", "exe = simple-mpi.exe", text)
     # remove program address
-    text = re.sub(r"at 0[xX][0-9a-fA-F]+", "at [hex address]", text)
+    text = re.sub(r"0[xX][0-9a-fA-F]+", "[hex address]", text)
     # remove trailing whitespace (causes
     text = re.sub(r"\s+\n", "\n", text)
     # remove $x variable notation (new lldb dropped it e.g., $0 = some_value)
@@ -108,6 +108,9 @@ def run_test_for_backend(launch_command: str, name: str, backend_script: str):
         # remove run specific outputs
         result_txt = standardize_output(result_txt)
         answer_text = standardize_output(answer_text)
+
+        with open(f"answer-{name}-filtered.stdout", "w") as outfile:
+            outfile.write(result_txt)
 
         # print(result_txt)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -48,6 +48,8 @@ def strip_runtime_specific_output(text: str) -> str:
     text = re.sub(r"at 0[xX][0-9a-fA-F]+", "at [hex address]", text)
     # remove trailing whitespace (causes
     text = re.sub(r"\s+\n", "\n", text)
+    # remove $x variable notation (new lldb dropped it e.g., $0 = some_value)
+    text = re.sub(r"\$\d+\s+=\s+", "", text)
     return text
 
 
@@ -57,6 +59,10 @@ def standardize_output(text: str) -> str:
 
     def filter_mask(line: str) -> Union[str, None]:
         if re.search(r"\d+:Reading.*from remote target...", line):
+            return None
+        if re.search(r"\[thread id\]", line):
+            return None
+        if re.search(r"\[proc id\]", line):
             return None
         return line
 
@@ -179,7 +185,7 @@ def test_mdb_timeout() -> None:
     with open("mdb-attach.log") as logfile:
         result_txt = "".join(logfile.readlines())
 
-    with open("tests/output/timeout.log") as logfile:
+    with open("tests/output/mdb-attach-log") as logfile:
         answer_text = "".join(logfile.readlines())
 
     assert result_txt == answer_text


### PR DESCRIPTION
There were a couple of issues that mdb had which are resolved by this
commit:
- <CTRL+C> sends interrupt but sometimes the output breaks
- starting `mdb attach` before `mdb launch` would slip into an infinite
  loop
- sometimes the launcher would get stuck in an infinite loop anyway
- exiting `mdb attach` would print loads of exceptions

The main changes that fix this are:

- `_forward_all_debuggers_to_client` making sure debuggers are
  initialized before running `asyncio.gather(*tasks)`
  - previously you could enter infinite loop because self.debuggers was
    an empty list so we would await no tasks and get stuck in infinite
    loop.
- `async_connection.py` catch `asyncio.IncompleteReadError` and return
  `None`.
- In `exchange_server.py` handle `None` return values
    - exit infinite loop in `_forward_all_debuggers_to_client`
    - exit infinite loop in `client_loop` to shutdown client safely