### PR TITLE
bug: fix ordering of output from debuggers

### DIFF
--- a/src/mdb/messages.py
+++ b/src/mdb/messages.py
@@ -20,7 +20,15 @@ class Message:
     @staticmethod
     def from_json(text: bytes) -> "Message":
         msg = json.loads(text.decode()[: -len(END_BYTES)])
-        return Message(msg["msg_type"], msg["data"])
+        if msg["msg_type"] == "exchange_command_response":
+            # the dictionary of results that comes back from the debuggers
+            # should be of type [int, str] but this gets destroyed by
+            # json.loads()
+            results = {int(k): v for k, v in msg["data"]["results"].items()}
+            msg["data"]["results"] = results
+            return Message(msg["msg_type"], msg["data"])
+        else:
+            return Message(msg["msg_type"], msg["data"])
 
     @staticmethod
     def debug_conn_request() -> "Message":


### PR DESCRIPTION
fixes #45 

The `exchange_command_response` coming back from the exchange server is deserialized by `json.loads()`. This converts the dictionary from `{int: str}` to `{str: str}` which was ruining the sorting algorithm `sort_debug_response` in `utils.py`. This is resolved in this PR by manually converting the dictionary type for messages (`msg`) with type `msg["msg_type"] == exchange_command_response`