### PR TITLE
feat: allow user to redirect stdout of target program

### DIFF
--- a/src/mdb/backend.py
+++ b/src/mdb/backend.py
@@ -29,7 +29,12 @@ class DebugBackend(ABC):
 
     @property
     @abstractmethod
-    def start_commands(self) -> list[str]:
+    def default_options(self) -> list[str]:
+        pass
+
+    @property
+    @abstractmethod
+    def start_command(self) -> str:
         pass
 
     @property
@@ -57,9 +62,13 @@ class GDBBackend(DebugBackend):
         return r"\(gdb\)"
 
     @property
-    def start_commands(self) -> list[str]:
-        commands = ["set pagination off", "set confirm off", "start"]
+    def default_options(self) -> list[str]:
+        commands = ["set pagination off", "set confirm off"]
         return commands
+
+    @property
+    def start_command(self) -> str:
+        return "start"
 
     @property
     def float_regex(self) -> str:
@@ -84,8 +93,12 @@ class LLDBBackend(DebugBackend):
         return r"\(lldb\)"
 
     @property
-    def start_commands(self) -> list[str]:
-        return ["b main", "run"]
+    def default_options(self) -> list[str]:
+        return ["b main"]
+
+    @property
+    def start_command(self) -> str:
+        return "run"
 
     @property
     def float_regex(self) -> str:

--- a/src/mdb/mdb_launch.py
+++ b/src/mdb/mdb_launch.py
@@ -86,6 +86,12 @@ Server_opts = TypedDict(
     help="Directory where mdb SSL/TLS certificate and key are stored.",
 )
 @click.option(
+    "--redirect-stdout",
+    type=click.File("w"),
+    required=False,
+    help="Redirect stdout from the target binary. If omitted, stdout will not be redirected.",
+)
+@click.option(
     "-r",
     "--auto-restart",
     is_flag=True,
@@ -118,6 +124,7 @@ def launch(
     port: int,
     backend: str,
     target: click.File,
+    redirect_stdout: click.File,
     auto_restart: bool,
     log_level: str,
     mdb_home: str,
@@ -172,6 +179,9 @@ def launch(
         "select": select,
         "connection_attempts": connection_attempts,
         "target": target.name,
+        "redirect_stdout": (
+            redirect_stdout.name if redirect_stdout is not None else None
+        ),
     }
 
     wrapper_launcher = WrapperLauncher(wl_opts)


### PR DESCRIPTION
fixes #53 

allow user to redirect `stdout` of target program to a file.

User can specify the option `--redirect-stdout` in the mdb launcher (`mdb launch`)