### PR TITLE
feat: allow user to override config option name

### DIFF
--- a/src/mdb/mdb_launch.py
+++ b/src/mdb/mdb_launch.py
@@ -60,6 +60,12 @@ Server_opts = TypedDict(
     help="MPI launcher e.g., mpirun, mpiexec, srun etc.",
 )
 @click.option(
+    "--mpi-config-opt",
+    default="",
+    show_default=True,
+    help="mdb will try to automatically detect the option name for the --app/--configfile option. This option overrides the automatic detection.",
+)
+@click.option(
     "-p",
     "--port",
     default=2000,
@@ -121,6 +127,7 @@ def launch(
     select: str | None,
     hostname: str,
     mpi_command: str,
+    mpi_config_opt: str,
     port: int,
     backend: str,
     target: click.File,
@@ -174,6 +181,7 @@ def launch(
         "backend": backend,
         "hostname": hostname,
         "mpi_command": mpi_command,
+        "mpi_config_opt": mpi_config_opt,
         "port": port,
         "ranks": ranks,
         "select": select,

--- a/src/mdb/mdb_wrapper.py
+++ b/src/mdb/mdb_wrapper.py
@@ -20,6 +20,7 @@ Wrapper_opts = TypedDict(
         "backend": str,
         "hostname": str,
         "mpi_command": str,
+        "mpi_config_opt": str,
         "port": int,
         "ranks": int,
         "select": str,
@@ -135,6 +136,7 @@ class WrapperLauncher:
         self.target = prog_opts["target"]
         self.redirect_stdout = prog_opts["redirect_stdout"]
         self.mpi_command = prog_opts["mpi_command"]
+        self.mpi_config_opt = prog_opts["mpi_config_opt"]
         self.select = parse_ranks(prog_opts["select"])
         self.appfile = prog_opts["appfile"]
         self.backend = prog_opts["backend"]
@@ -203,12 +205,16 @@ class WrapperLauncher:
         """
         appfile = self.appfile
         launcher = self.mpi_command
+        if self.mpi_config_opt != "":
+            return f"{launcher} --{self.mpi_config_opt} {appfile}"
         if self.mpi_mode == "intel":
             return f"{launcher} --configfile {appfile}"
         elif self.mpi_mode == "open mpi":
             return f"{launcher} --app {appfile}"
         else:
-            logging.error("error: MPI mode not supported.")
+            logging.error(
+                "error: MPI mode not supported. Try specifying the --configfile option."
+            )
             exit(1)
         return
 


### PR DESCRIPTION
fixes #44 
fixes #31

allow user to override mpi config option name by setting `--mpi-config-opt`

For example, on systems that use cray mpi, the mpi config option is called `--config` or `--configfile`. To specify this use a `mdb launch` command like the following:

```
mdb launch -n 8 -t ./simple-mpi.exe --mpi-config-opt configfile
```