### PR TITLE
feat: add debug client connection status to launcher

### DIFF
--- a/src/mdb/mdb_client.py
+++ b/src/mdb/mdb_client.py
@@ -51,4 +51,5 @@ class Client(AsyncClient):
         msg = await self.connect_to_exchange(Message.mdb_conn_request())
         self.number_of_ranks = msg.data["no_of_ranks"]
         self.backend_name = msg.data["backend_name"]
+        self.select_str = msg.data["select_str"]
         return

--- a/src/mdb/mdb_launch.py
+++ b/src/mdb/mdb_launch.py
@@ -207,6 +207,7 @@ def launch(
         "number_of_ranks": ranks,
         "backend": backend,
         "launch_task": launch_task,
+        "select": select,
     }
     server = AsyncExchangeServer(opts=exchange_opts)
     loop.create_task(server.start_server())

--- a/src/mdb/messages.py
+++ b/src/mdb/messages.py
@@ -69,7 +69,9 @@ class Message:
         )
 
     @staticmethod
-    def mdb_conn_response(no_of_ranks: int, backend_name: str) -> "Message":
+    def mdb_conn_response(
+        no_of_ranks: int, backend_name: str, select_str: str
+    ) -> "Message":
         return Message(
             "mdb_conn_response",
             {
@@ -77,6 +79,7 @@ class Message:
                 "to": MDB_CLIENT,
                 "no_of_ranks": no_of_ranks,
                 "backend_name": backend_name,
+                "select_str": select_str,
             },
         )
 

--- a/tests/output/answer-gdb.stdout
+++ b/tests/output/answer-gdb.stdout
@@ -29,6 +29,8 @@ hello
 ************************************************************************
 1:#0  simple () at simple-mpi.f90:15
 unrecognized command [made-up-command]. Type help to find out list of possible commands.
+Error: user specified option [select] must be subset of available ranks (check mdb launch command).
+select = [10] but available ranks are [0-1].
 1:Continuing.
 1:
 1:Thread 1 "simple-mpi.exe" hit Breakpoint 3, simple () at simple-mpi.f90:17

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -109,7 +109,6 @@ def run_test_for_backend(
             answer_text = infile.read()
             answer_text = answer_text.split("\n")
 
-        print(result_txt)
         assert len(result_txt) == len(answer_text)
 
         for result_line, answer_line in zip(result_txt, answer_text):
@@ -125,6 +124,7 @@ command continue
 command 0 continue
 command bt -1
 made-up-command
+select 10
 select 1
 command continue
 execute deliberately-missing-file.mdb


### PR DESCRIPTION
this PR adds a useful status update to the `mdb launch` command so that users know when all the debuggers are successfully connected.

It looks something like this: 

```
$ mdb launch -n 64 -t ./simple-mpi.exe --mpi-command "mpirun --oversubscribe"                                                                                                                                                 
connecting to debuggers ... (64/64)                                                                                                                                                                                                                                                       
all debug clients connected
```

The count updates in real time and will display `(x/N)` where `x` is the number of connected debug clients and `N` is the total number of ranks, in this case 64. 

This PR also changes how the `mdb attach` client works. Previously, the user could specify the number of rank to debug using CLI option `--select`/`-s`. This how now been removed and the `attach` client directly gets the available debug procs from the `exchange server`. The user can still specify custom ranks to debug, as before, using the `select` command inside the `mdb attach` client.

### TODO
- [x] update the quick start example in the docs 