### PR TITLE
chore: update workflow files

### DIFF
--- a/.github/workflows/code-validation.yml
+++ b/.github/workflows/code-validation.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  validate:
+  style:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  validate:
+  tests:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
rename the github action job names. Both in `.github/workflows/code-validation.yml` and `.github/workflows/tests.yml` the status names were validation. In order to ensure both tests are required to pass (via branch protection rules) they have been renamed to `style` and `tests` respectively.