### PR TITLE
feat: testing hostfile option

### DIFF
--- a/src/mdb/mdb_wrapper.py
+++ b/src/mdb/mdb_wrapper.py
@@ -155,6 +155,8 @@ class WrapperLauncher:
         for rank in range(self.ranks):
             if rank in self.select:
                 options = [
+                    "--hostfile",
+                    "./myhost",
                     "-n",
                     "1",
                     "mdb",


### PR DESCRIPTION
attempt at resolving #66 

This is not ready to be merged. It is more of a hack than a solution.

The proper solution would be to allow users to add additional `mpirun` options via the CLI