### PR TITLE
Add plugin-based debugger backend support, refactor gdb & lldb

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,10 @@ MPI applications, whilst also trying to take advantage of as much of `gdb`'s bui
 
 Raise an issue and label it as `enhancement`.
 
+## Adding a Debugger Backend
+
+To integrate a new debugger backend, add a new Python file to the `src/mdb/plugins/` folder, named after the debugger (`[debugger-name].py`). Inside this file, define a class that extends `DebugBackend` to provide an interface for interacting with your debugger and specify its properties.
+
 ## Submitting Pull Requests
 
 Good pull requests—patches, improvements, new features—are a fantastic help. They should remain focused in scope and avoid

--- a/src/mdb/debug_client.py
+++ b/src/mdb/debug_client.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 import pexpect  # type: ignore
 
 from .async_client import AsyncClient
-from .backend import DebugBackend, GDBBackend, LLDBBackend
+from .backend import backends
 from .messages import Message
 from .utils import strip_bracketted_paste
 
@@ -23,10 +23,12 @@ class DebugClient(AsyncClient):
         self.stdout = opts["redirect_stdout"]
         self.args = opts["args"]
         self.is_running = False
-        if opts["backend"].lower() == "gdb":
-            self.backend: DebugBackend = GDBBackend()
-        elif opts["backend"].lower() == "lldb":
-            self.backend = LLDBBackend()
+
+        backend_name = opts["backend"].lower()
+        if backend_name in backends:
+            self.backend = backends[backend_name]()
+        else:
+            raise ValueError(f"Debugger backend is not supported: {backend_name}")
 
         logger.debug("Selected backend: %s", self.backend.name)
 

--- a/src/mdb/mdb_shell.py
+++ b/src/mdb/mdb_shell.py
@@ -48,9 +48,12 @@ class mdbShell(cmd.Cmd):
         self.exchange_select = parse_ranks(self.exchange_select_str)
         self.select_str = self.exchange_select_str
         self.select = self.exchange_select
-        for backend in backends:
-            if backend().name == shell_opts["backend_name"].lower():
-                self.backend = backend()
+        backend_name = shell_opts["backend_name"].lower()
+        if backend_name in backends:
+            self.backend = backends[backend_name]()
+        else:
+            raise ValueError(f"Debugger backend is not supported: {backend_name}")
+
         self.prompt = f"(mdb {self.select_str}) "
         self.client = client
         self.exec_script = shell_opts["exec_script"]

--- a/src/mdb/plugins/gdb.py
+++ b/src/mdb/plugins/gdb.py
@@ -1,0 +1,33 @@
+from mdb.backend import DebugBackend
+
+
+class GDBBackend(DebugBackend):
+
+    @property
+    def name(self) -> str:
+        return "gdb"
+
+    @property
+    def debug_command(self) -> str:
+        return "gdb -q"
+
+    @property
+    def argument_separator(self) -> str:
+        return "--args"
+
+    @property
+    def prompt_string(self) -> str:
+        return r"\(gdb\)"
+
+    @property
+    def default_options(self) -> list[str]:
+        commands = ["set pagination off", "set confirm off"]
+        return commands
+
+    @property
+    def start_command(self) -> str:
+        return "start"
+
+    @property
+    def float_regex(self) -> str:
+        return r"\d+ = ([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)"

--- a/src/mdb/plugins/lldb.py
+++ b/src/mdb/plugins/lldb.py
@@ -1,0 +1,31 @@
+from mdb.backend import DebugBackend
+
+
+class LLDBBackend(DebugBackend):
+    @property
+    def name(self) -> str:
+        return "lldb"
+
+    @property
+    def debug_command(self) -> str:
+        return "lldb --source-quietly --no-use-colors"
+
+    @property
+    def argument_separator(self) -> str:
+        return "--"
+
+    @property
+    def prompt_string(self) -> str:
+        return r"\(lldb\)"
+
+    @property
+    def default_options(self) -> list[str]:
+        return ["b main"]
+
+    @property
+    def start_command(self) -> str:
+        return "run"
+
+    @property
+    def float_regex(self) -> str:
+        return r"\d+ = ([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)"


### PR DESCRIPTION
This PR adds a plugin-based debugger system to improve maintainability and extendability. Instead of hardcoding debuggers, they are now implemented as separate plugins inside the `src/mdb/plugins` directory.

- Introduced a plugin architecture for debugger backends.  
- Moved `gdb` and `lldb` implementations into separate plugin files.  
- Refactored core code to dynamically load debuggers instead of hardcoding them.  
- Updated documentation and added a short guide to `CONTRIBUTING.md` on how to add new debugger backends.

**To-Do:**
-  Ensure all tests pass on CI.
-  Refactor debugger backend tests to dynamically detect and test existing backends instead of hardcoding each. (Optional, as the current test setup also works.)