### PR TITLE
Add a plugin to support cuda-gdb

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,9 +1,19 @@
+# check if cuda compiler exists
+ifneq ($(shell which nvcc 2>/dev/null),)
+    HAS_CUDA=true
+else
+    HAS_CUDA=false
+endif
+
 FC:=mpif90
 CC:=mpicc
 CXX:=mpic++
 objects = simple-mpi.o
 cppobjects = simple-mpi-cpp.o
 programs = simple-mpi.exe simple-mpi-cpp.exe simple-memory.exe
+ifeq ($(HAS_CUDA),true)
+    programs += saxpy-mpi.exe
+endif
 FLAGS=-g -O0
 .PHONY: all
 
@@ -23,6 +33,11 @@ simple-mpi-cpp.exe: simple-mpi-cpp.o
 
 simple-memory.exe: simple-memory.c
 	$(CC) $(FLAGS) $^ -o $@
+
+ifeq ($(HAS_CUDA),true)
+saxpy-mpi.exe: saxpy-mpi.cu
+	$(CXX) $(FLAGS) $^ -o $@
+endif
 
 clean:
 	rm -f *.o *.exe

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,43 +1,33 @@
-# check if cuda compiler exists
-ifneq ($(shell which nvcc 2>/dev/null),)
-    HAS_CUDA=true
-else
-    HAS_CUDA=false
-endif
+# default make will build cpu only e.g.
+# $ make
+# which is equivalent to
+# $ make cpu
+# If you want to build the gpu example, specify gpu or all e.g.,
+# $ make all
+# or
+# $ make gpu
 
 FC:=mpif90
 CC:=mpicc
 CXX:=mpic++
-objects = simple-mpi.o
-cppobjects = simple-mpi-cpp.o
-programs = simple-mpi.exe simple-mpi-cpp.exe simple-memory.exe
-ifeq ($(HAS_CUDA),true)
-    programs += saxpy-mpi.exe
-endif
 FLAGS=-g -O0
-.PHONY: all
+.PHONY: all cpu gpu
 
-all: $(programs)
+cpu: simple-mpi.exe simple-mpi-cpp.exe simple-memory.exe
+gpu: saxpy-mpi.exe
+all: cpu gpu
 
-$(objects): %.o: %.f90
-	$(FC) $(FLAGS) -c $(FFLAGS) $^ -o $@
+simple-mpi.exe: simple-mpi.f90
+	$(FC) $(FLAGS) $^ -o $@
 
-$(cppobjects): %.o: %.cpp
-	$(CXX) $(FLAGS) -c $(FFLAGS) $^ -o $@
-
-simple-mpi.exe: simple-mpi.o
-	$(FC) $(LDFLAGS) $^ -o $@
-
-simple-mpi-cpp.exe: simple-mpi-cpp.o
-	$(CXX) $(LDFLAGS) $^ -o $@
+simple-mpi-cpp.exe: simple-mpi-cpp.cpp
+	$(CXX) $(FLAGS) $^ -o $@
 
 simple-memory.exe: simple-memory.c
 	$(CC) $(FLAGS) $^ -o $@
 
-ifeq ($(HAS_CUDA),true)
 saxpy-mpi.exe: saxpy-mpi.cu
 	$(CXX) $(FLAGS) $^ -o $@
-endif
 
 clean:
-	rm -f *.o *.exe
+	rm -f *.exe

--- a/examples/saxpy-mpi.cu
+++ b/examples/saxpy-mpi.cu
@@ -1,0 +1,55 @@
+#include <stdio.h>
+#include <mpi.h>
+
+__global__
+void saxpy(int n, float a, float *x, float *y)
+{
+  int i = blockIdx.x*blockDim.x + threadIdx.x;
+  if (i < n) y[i] = a*x[i] - y[i];
+}
+
+int main(void)
+{
+  int N = 1<<10;
+  float *x, *y, *d_x, *d_y;
+  x = (float*)malloc(N*sizeof(float));
+  y = (float*)malloc(N*sizeof(float));
+
+  int process_rank, size_of_cluster;
+
+  MPI_Init(NULL, NULL);
+  MPI_Comm_size(MPI_COMM_WORLD, &size_of_cluster);
+  MPI_Comm_rank(MPI_COMM_WORLD, &process_rank);
+
+  printf("process rank = %d\n", process_rank);
+
+  if (process_rank >= 0){
+    cudaMalloc(&d_x, N*sizeof(float)); 
+    cudaMalloc(&d_y, N*sizeof(float));
+
+    for (int j = 0; j < 2000; ++j) {
+      for (int i = 0; i < N; i++) {
+        x[i] = 1.0f * i * (process_rank + 1);
+        y[i] = 2.0f * i * (process_rank + 1);
+      }
+      cudaMemcpy(d_x, x, N*sizeof(float), cudaMemcpyHostToDevice);
+      cudaMemcpy(d_y, y, N*sizeof(float), cudaMemcpyHostToDevice);
+
+      // Perform SAXPY on 1M elements
+      saxpy<<<(N+255)/256, 256>>>(N, 2.0f, d_x, d_y);
+
+      cudaMemcpy(y, d_y, N*sizeof(float), cudaMemcpyDeviceToHost);
+    }
+
+    float maxError = 0.0f;
+    for (int i = 0; i < N; i++)
+      maxError = max(maxError, abs(y[i]));
+    printf("Max error: %f\n", maxError);
+
+    cudaFree(d_x);
+    cudaFree(d_y);
+  }
+  free(x);
+  free(y);
+  MPI_Finalize();
+}

--- a/examples/simple-mpi-cuda.mdb
+++ b/examples/simple-mpi-cuda.mdb
@@ -1,0 +1,14 @@
+broadcast start
+b 8
+b 26
+c
+p process_rank
+info proc
+c
+info local
+p x[0]@10
+broadcast stop
+plot x[1]
+command clear
+command c
+quit

--- a/src/mdb/plugins/cuda-gdb.py
+++ b/src/mdb/plugins/cuda-gdb.py
@@ -31,3 +31,6 @@ class CudaGDBBackend(DebugBackend):
     @property
     def float_regex(self) -> str:
         return r"\d+ = ([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)"
+
+    def runtime_options(self, opts: dict[str, str]) -> list[str]:
+        return []

--- a/src/mdb/plugins/cuda-gdb.py
+++ b/src/mdb/plugins/cuda-gdb.py
@@ -1,0 +1,33 @@
+from mdb.backend import DebugBackend
+
+
+class CudaGDBBackend(DebugBackend):
+
+    @property
+    def name(self) -> str:
+        return "cuda-gdb"
+
+    @property
+    def debug_command(self) -> str:
+        return "cuda-gdb -q"
+
+    @property
+    def argument_separator(self) -> str:
+        return "--args"
+
+    @property
+    def prompt_string(self) -> str:
+        return r"\(cuda-gdb\)"
+
+    @property
+    def default_options(self) -> list[str]:
+        commands = ["set pagination off", "set confirm off"]
+        return commands
+
+    @property
+    def start_command(self) -> str:
+        return "start"
+
+    @property
+    def float_regex(self) -> str:
+        return r"\d+ = ([+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?)"


### PR DESCRIPTION
This PR adds support for the cuda-gdb backend.
- Added a cuda-gdb plugin.
- added an example CUDA program for testing cuda-gdb functionality (also updated Makefile to check for nvcc availability and build the CUDA program if available).

To-Do:
- Add tests for cuda-gdb (in the future, as there is no GPU support in CI and the current focus is on core functionality).