### PR TITLE
Message header integration

### DIFF
--- a/src/mdb/async_connection.py
+++ b/src/mdb/async_connection.py
@@ -21,7 +21,7 @@ class AsyncConnection:
     async def recv_message(self) -> "Message":
         try:
             length = await self.reader.readexactly(4)
-            length = int.from_bytes(length, byteorder='big')
+            length = int.from_bytes(length, byteorder='big', signed=False)
             raw_msg = await self.reader.readexactly(length)
         except Exception as e:
             logger.exception("async read error")
@@ -33,7 +33,7 @@ class AsyncConnection:
     async def send_message(self, msg: Message) -> None:
         try:
             data = msg.to_json()
-            length_header = len(data).to_bytes(4, byteorder='big')
+            length_header = data.__len__().to_bytes(4, byteorder='big', signed=False)
             
             self.writer.write(length_header)
             self.writer.write(data)

--- a/src/mdb/async_connection.py
+++ b/src/mdb/async_connection.py
@@ -16,13 +16,13 @@ class AsyncConnection:
     ):
         self.reader = reader
         self.writer = writer
-        self.numlengthBytes = 8
+        self.num_bytes = 8  # number of bytes used to represent int
         self.type = ""
 
     async def recv_message(self) -> "Message":
         try:
-            length = await self.reader.readexactly(self.numlengthBytes)
-            length = int.from_bytes(length, byteorder="big", signed=False)
+            length_in_bytes = await self.reader.readexactly(self.num_bytes)
+            length = int.from_bytes(length_in_bytes, byteorder="big", signed=False)
             raw_msg = await self.reader.readexactly(length)
         except Exception as e:
             logger.exception("async read error")
@@ -35,7 +35,7 @@ class AsyncConnection:
         try:
             data = msg.to_json()
             length_header = len(data).to_bytes(
-                self.numlengthBytes, byteorder="big", signed=False
+                self.num_bytes, byteorder="big", signed=False
             )
 
             self.writer.write(length_header)

--- a/src/mdb/async_connection.py
+++ b/src/mdb/async_connection.py
@@ -16,11 +16,12 @@ class AsyncConnection:
     ):
         self.reader = reader
         self.writer = writer
+        self.numlengthBytes = 8
         self.type = ""
 
     async def recv_message(self) -> "Message":
         try:
-            length = await self.reader.readexactly(4)
+            length = await self.reader.readexactly(self.numlengthBytes)
             length = int.from_bytes(length, byteorder='big', signed=False)
             raw_msg = await self.reader.readexactly(length)
         except Exception as e:
@@ -33,7 +34,7 @@ class AsyncConnection:
     async def send_message(self, msg: Message) -> None:
         try:
             data = msg.to_json()
-            length_header = data.__len__().to_bytes(4, byteorder='big', signed=False)
+            length_header = data.__len__().to_bytes(self.numlengthBytes, byteorder='big', signed=False)
             
             self.writer.write(length_header)
             self.writer.write(data)

--- a/src/mdb/async_connection.py
+++ b/src/mdb/async_connection.py
@@ -22,7 +22,7 @@ class AsyncConnection:
     async def recv_message(self) -> "Message":
         try:
             length = await self.reader.readexactly(self.numlengthBytes)
-            length = int.from_bytes(length, byteorder='big', signed=False)
+            length = int.from_bytes(length, byteorder="big", signed=False)
             raw_msg = await self.reader.readexactly(length)
         except Exception as e:
             logger.exception("async read error")
@@ -34,8 +34,10 @@ class AsyncConnection:
     async def send_message(self, msg: Message) -> None:
         try:
             data = msg.to_json()
-            length_header = data.__len__().to_bytes(self.numlengthBytes, byteorder='big', signed=False)
-            
+            length_header = len(data).to_bytes(
+                self.numlengthBytes, byteorder="big", signed=False
+            )
+
             self.writer.write(length_header)
             self.writer.write(data)
             await self.writer.drain()

--- a/src/mdb/exchange_server.py
+++ b/src/mdb/exchange_server.py
@@ -118,7 +118,6 @@ class AsyncExchangeServer:
         conn.writer.close()
         await conn.writer.wait_closed()
 
-
     async def _forward_all_debuggers_to_client(self, conn: AsyncConnection) -> None:
         while True:
             tasks = [

--- a/src/mdb/exchange_server.py
+++ b/src/mdb/exchange_server.py
@@ -116,6 +116,8 @@ class AsyncExchangeServer:
 
         # do this incase we somehow fall through
         conn.writer.close()
+        await conn.writer.wait_closed()
+
 
     async def _forward_all_debuggers_to_client(self, conn: AsyncConnection) -> None:
         while True:

--- a/src/mdb/messages.py
+++ b/src/mdb/messages.py
@@ -9,6 +9,7 @@ MDB_CLIENT = "mdb client"
 DEBUG_CLIENT = "debug client"
 EXCHANGE = "exchange server"
 
+
 @dataclass
 class Message:
     msg_type: str

--- a/src/mdb/messages.py
+++ b/src/mdb/messages.py
@@ -9,9 +9,6 @@ MDB_CLIENT = "mdb client"
 DEBUG_CLIENT = "debug client"
 EXCHANGE = "exchange server"
 
-END_BYTES = b"_MDB_END_"
-
-
 @dataclass
 class Message:
     msg_type: str
@@ -19,7 +16,7 @@ class Message:
 
     @staticmethod
     def from_json(text: bytes) -> "Message":
-        msg = json.loads(text.decode()[: -len(END_BYTES)])
+        msg = json.loads(text.decode())
         if msg["msg_type"] == "exchange_command_response":
             # the dictionary of results that comes back from the debuggers
             # should be of type [int, str] but this gets destroyed by
@@ -152,4 +149,4 @@ class Message:
 
     def to_json(self) -> bytes:
         msg = dict(msg_type=self.msg_type, data=self.data)
-        return json.dumps(msg).encode() + END_BYTES
+        return json.dumps(msg).encode()


### PR DESCRIPTION
fixes #76

This PR is responsible for replacing `END_BYTES = _MDB_END_` with exact `message length` sent from `send_message`.