### PR TITLE
Add version command

### DIFF
--- a/src/mdb/mdb.py
+++ b/src/mdb/mdb.py
@@ -32,6 +32,13 @@ def run_main() -> None:
     pass
 
 
+@click.command()
+def version() -> None:
+    """Get the version number of mdb."""
+    print("1.0.4")
+
+
 main.add_command(attach)
 main.add_command(launch)
+main.add_command(version)
 main.add_command(wrapper)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    # Remove this once minimum Python version is 3.11
+    import pip._vendor.tomli as tomllib
+
+
+def test_version_number():
+    git_root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    print(git_root)
+
+    with open(os.path.join(git_root, "pyproject.toml"), "rb") as f:
+        version = tomllib.load(f)["project"]["version"].strip()
+
+    assert (
+        version == subprocess.check_output("mdb version", shell=True).decode().strip()
+    )


### PR DESCRIPTION
Adds a `mdb version` command that will output the version number of mdb.

Adds a test that this version number matches the number in pyproject.toml