### PR TITLE
fix: Update asyncio with compatibility for Python 3.14

### DIFF
--- a/src/mdb/mdb_attach.py
+++ b/src/mdb/mdb_attach.py
@@ -159,7 +159,8 @@ def attach_shell(
 
     client = Client(opts=client_opts)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     loop.run_until_complete(client.connect())
 

--- a/src/mdb/mdb_launch.py
+++ b/src/mdb/mdb_launch.py
@@ -201,7 +201,8 @@ def launch(
     wrapper_launcher = WrapperLauncher(wl_opts)
     wrapper_launcher.write_app_file()
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     cmd = wrapper_launcher.launch_command()
     logger.debug(f"launch command: {cmd}")

--- a/src/mdb/mdb_wrapper.py
+++ b/src/mdb/mdb_wrapper.py
@@ -121,7 +121,9 @@ def wrapper(
     dbg_client = DebugClient(opts)  # type: ignore
     logger.debug("debug client initialized")
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
     loop.run_until_complete(dbg_client.run())
     loop.close()
 


### PR DESCRIPTION
In Python 3.14, `asyncio.get_event_loop()` will error if there is no running loop rather than create and return a new running event loop.

Closes #87 