### PR TITLE
Alias for `-n` in launch command

### DIFF
--- a/src/mdb/mdb_launch.py
+++ b/src/mdb/mdb_launch.py
@@ -36,6 +36,7 @@ Server_opts = TypedDict(
 @click.command()
 @click.option(
     "-n",
+    "-np",
     "--ranks",
     default=1,
     show_default=True,


### PR DESCRIPTION
Hi @TomMelt! I tend to use `mpiexec -np` rather than `mpiexec -n` so often mistype `mdb launch -np`. Would you be interested in having `-np` as an alias?